### PR TITLE
Add new ISSUE_LABELS_TO_KEEP_OPEN input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ INPUT_PACKAGE_NAME="react-router" \
 INPUT_DIRECTORY_TO_CHECK="packages/." \
 INPUT_GITHUB_REPOSITORY="remix-run/react-router" \
 INPUT_INCLUDE_NIGHTLY="false" \
+INPUT_ISSUE_LABELS_TO_REMOVE="awaiting release" \
+INPUT_ISSUE_LABELS_TO_KEEP_OPEN="🗺️Roadmap" \
 node ../release-comment-action/src/index.ts
 */
 


### PR DESCRIPTION
This allows us to skip issues with a given label, used for issues moving along the react router roadmap that will be included in multiple releases leading up to an eventual stable release and shouldn't be auto-closed.